### PR TITLE
Avoid delay on return to R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyxl 1.0.2.9000
 
+* Noticeably faster for large files.
+
 # tidyxl 1.0.2
 
 * Correctly constructs formulas where references are preceded by operators, e.g.

--- a/src/xlsxbook.cpp
+++ b/src/xlsxbook.cpp
@@ -57,13 +57,22 @@ void xlsxbook::cacheStrings() {
   sharedStrings.parse<rapidxml::parse_strip_xml_namespaces>(&xml[0]);
 
   rapidxml::xml_node<>* sst = sharedStrings.first_node("sst");
+
+  unsigned long int n = 0;
   rapidxml::xml_attribute<>* uniqueCount = sst->first_attribute("uniqueCount");
-  if (uniqueCount != NULL) {
-    unsigned long int n = strtol(uniqueCount->value(), NULL, 10);
-    strings_.reserve(n);
+  if (uniqueCount != NULL) { // The count is stored in the file
+    n = strtol(uniqueCount->value(), NULL, 10);
+  } else { // Count them manually
+    for (rapidxml::xml_node<>* string = sst->first_node();
+        string; string = string->next_sibling()) {
+      n += 1;
+    }
   }
+  strings_.reserve(n);
+  strings_formatted_ = Rcpp::List(n);
 
   // 18.4.8 si (String Item) [p1725]
+  unsigned long int i = 0;
   for (rapidxml::xml_node<>* string = sst->first_node();
       string; string = string->next_sibling()) {
     std::string out;
@@ -71,7 +80,8 @@ void xlsxbook::cacheStrings() {
     strings_.push_back(out);
 
     Rcpp::List out_df = parseFormattedString(string, styles_);
-    strings_formatted_.push_back(out_df);
+    strings_formatted_[i] = out_df;
+    i += 1;
   }
 }
 

--- a/src/xlsxbook.h
+++ b/src/xlsxbook.h
@@ -15,7 +15,7 @@ class xlsxbook {
     Rcpp::CharacterVector sheet_names_;    // worksheet names
     Rcpp::CharacterVector comments_paths_; // comments files
     std::vector<std::string> strings_;     // strings table
-    std::vector<Rcpp::List> strings_formatted_; // strings with inline formatting
+    Rcpp::List strings_formatted_;         // strings with inline formatting
                                                 // list of data frames
     xlsxstyles styles_;
 


### PR DESCRIPTION
The return from Rcpp to R was really slow for large spreadsheets, which I suspect was due to copying or garbage collection.  It was definitely something to do with the parsed strings, which were stored in a `std::vector<Rcpp:List>` (one string in each `Rcpp::List`).  By experiment, using another `Rcpp::List` to wrap the individual ones is much quicker.