### PR TITLE
Don't even think about importing blank cells

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # tidyxl 1.0.2.9000
 
 * Noticeably faster for large files.
+* Omission of blank cells with `include_blank_cells = FALSE` had a bug that
+    returned blank cells as an empty row in the `xlsx_cells()` data frame.
 
 # tidyxl 1.0.2
 

--- a/src/xlsxbook.h
+++ b/src/xlsxbook.h
@@ -28,6 +28,8 @@ class xlsxbook {
 
     Rcpp::List information_;             // dataframes of cells
 
+    bool include_blank_cells_; // whether to include cells with no value
+
     // Vectors of cell properties, to be wrapped in a data frame
     Rcpp::CharacterVector sheet_;     // The worksheet that a cell is in
     Rcpp::CharacterVector address_;   // Value of cell node r
@@ -68,7 +70,7 @@ class xlsxbook {
     void countCells();
     void initializeColumns();
     void cacheCells();
-    void cacheInformation(const bool& include_blank_cells);
+    void cacheInformation();
 
 };
 

--- a/src/xlsxcell.cpp
+++ b/src/xlsxcell.cpp
@@ -75,7 +75,6 @@ void xlsxcell::cacheValue(
   if (v != NULL) {
     vvalue = v->value();
   } else {
-    // TODO: don't construct the cell
     book.is_blank_[i] = true;
   }
 

--- a/src/xlsxsheet.h
+++ b/src/xlsxsheet.h
@@ -22,12 +22,14 @@ class xlsxsheet {
     std::map<int, shared_formula> shared_formulas_;
     xlsxbook& book_; // reference to parent workbook
     std::map<std::string, std::string> comments_; // lookup table of comments
+    bool include_blank_cells_; // whether to include cells with no value
 
     xlsxsheet(
         const std::string& name,
         std::string& sheet_xml,
         xlsxbook& book,
-        Rcpp::String comments_path);
+        Rcpp::String comments_path,
+        const bool& include_blank_cells);
 
     void cacheDefaultRowColDims(rapidxml::xml_node<>* worksheet);
     void cacheColWidths(rapidxml::xml_node<>* worksheet);
@@ -35,8 +37,7 @@ class xlsxsheet {
     void cacheComments(Rcpp::String comments_path);
     void parseSheetData(
         rapidxml::xml_node<>* sheetData,
-        unsigned long long int& i,
-        const bool& include_blank_cells);
+        unsigned long long int& i);
     void appendComments(unsigned long long int& i);
 
 };

--- a/tests/testthat/test-xlsx_cells.R
+++ b/tests/testthat/test-xlsx_cells.R
@@ -44,6 +44,8 @@ test_that("include_blank_cells works", {
   cells <- xlsx_cells("./examples.xlsx", include_blank_cells = FALSE)
   blanks <- cells[cells$is_blank, ]
   non_blanks <- cells[!cells$is_blank, ]
+  unpopulated_blanks <- cells[is.na(cells$row), ]
   expect_equal(nrow(blanks), 0L)
   expect_gt(nrow(non_blanks), 0L)
+  expect_equal(nrow(unpopulated_blanks), 0L)
 })


### PR DESCRIPTION
The `include_blank_cells` argument had the effect that cells contents wouldn't
be explored, but a row would still be returned in the final data frame, with
`NA` in the `row` and `col` columns.  This is now fixed.