### PR TITLE
Fix testthat error on xlex class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyxl
 Title: Read Untidy Excel Files
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(
     person("Duncan", "Garmonsway", email = "nacnudus@gmail.com", role = c("aut", "cre")),
     person("Hadley", "Wickham", role = c("ctb"), comment = "Author of included readxl fragments"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyxl 1.0.5
 
+* Fix tests for `xlex()` (#57).
+
 # tidyxl 1.0.4
 
 * Compatibility: imports cell data validation rules from files created by Office

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# tidyxl 1.0.5
+
 # tidyxl 1.0.4
 
 * Compatibility: imports cell data validation rules from files created by Office


### PR DESCRIPTION
`xlex()` returns a tibble with an extra class `"xlex"` for `print.xlex()`.  This
extra class is now detected by `testthat::expect_equal()` when comparing it to a
contrived tibble.

The tests now use a wrapper of `xlex()` called `un_xlex()` that strips the
`"xlex"` class so that it can be safely compared with a tibble.

Alternatively, I could have defined a wrapper class for `tribble()` that added
the extra class, but it would have been more trouble to format the code nicely.