### PR TITLE
Fix error message expectation to comply with RcppCore/Rcpp/pull/1225

### DIFF
--- a/tests/testthat/test-maybe_xlsx.R
+++ b/tests/testthat/test-maybe_xlsx.R
@@ -11,6 +11,6 @@ test_that("non-xlsx files are detected", {
   expect_error(xlsx_cells("examples.xlsm", check_filetype = FALSE), NA)
   expect_error(xlsx_cells("examples.xltx", check_filetype = FALSE), NA)
   expect_error(xlsx_cells("examples.xltm", check_filetype = FALSE), NA)
-  expect_error(xlsx_cells("examples.xlsb", check_filetype = FALSE), "Evaluation.*")
+  expect_error(xlsx_cells("examples.xlsb", check_filetype = FALSE), "Couldn't find.*")
   expect_error(xlsx_cells("examples.xls"), "The file format*")
 })


### PR DESCRIPTION
We are preparing a new change in Rcpp that will switch to the newer and faster evaluation mechanism introduced in R 3.5 (see RcppCore/Rcpp/pull/1225). With this change, we observed that one test here fails because it expects an Rcpp error to start with `Evaluation error: <msg>`, which is something that only the old slow mechanism prints out. Therefore, here I'm just changing the expectation to the real error message, and thus this is compatible with both evaluation mechanisms.